### PR TITLE
CI: test Renovate upgrade from JDK 27 EA build 14

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,6 +30,17 @@
       "matchStrings": ["USE_BAZEL_VERSION: \"(?<currentValue>.*?)\""],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "bazelbuild/bazel"
+    },
+    {
+      "description": "Update JDK_EA_BUILD in GitHub Actions",
+      "fileMatch": ["^\\.github/workflows/ci\\.yml$"],
+      "matchStrings": [
+        "JDK_EA_MAJOR:\\s+\"(?<major>\\d+)\"[\\s\\S]*?JDK_EA_BUILD:\\s+\"(?<currentValue>\\d+)\""
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "openjdk/jdk",
+      "versioningTemplate": "loose",
+      "extractVersionTemplate": "^jdk-{{{major}}}\\+(?<version>\\d+)$"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,17 +30,6 @@
       "matchStrings": ["USE_BAZEL_VERSION: \"(?<currentValue>.*?)\""],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "bazelbuild/bazel"
-    },
-    {
-      "description": "Update JDK_EA_BUILD in GitHub Actions",
-      "fileMatch": ["^\\.github/workflows/ci\\.yml$"],
-      "matchStrings": [
-        "JDK_EA_MAJOR:\\s+\"(?<major>\\d+)\"[\\s\\S]*?JDK_EA_BUILD:\\s+\"(?<currentValue>\\d+)\""
-      ],
-      "datasourceTemplate": "github-releases",
-      "versioningTemplate": "loose",
-      "depNameTemplate": "adoptium/temurin{{{major}}}-binaries",
-      "extractVersionTemplate": "^jdk-\\d+\\+(?<version>\\d+)"
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
       JAVA_VERSION: ${{ matrix.java.version }}
       USE_BAZEL_VERSION: "9.0.1"
       JDK_EA_MAJOR: "27"
+      JDK_EA_BUILD: "15"
     strategy:
       fail-fast: true
       matrix:
@@ -217,7 +218,8 @@ jobs:
       with:
         # Install the requested EA JDK second, to make it the default on which everything else runs.
         website: jdk.java.net
-        release: ${{ matrix.java.version }}
+        release: ${{ env.JDK_EA_MAJOR }}
+        version: ${{ format('{0}-ea+{1}', env.JDK_EA_MAJOR, env.JDK_EA_BUILD) }}
     - name: Inject JAVA_HOME_21_64 into `gradle.properties` to always use JDK 21 for Gradle
       run: mkdir -p ~/.gradle && echo "org.gradle.java.home=$JAVA_HOME_21_X64" >> ~/.gradle/gradle.properties
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,9 +218,8 @@ jobs:
         # Install the requested EA JDK second, to make it the default on which everything else runs.
         website: jdk.java.net
         release: ${{ matrix.java.version }}
-        cache: 'gradle'
     - name: Inject JAVA_HOME_21_64 into `gradle.properties` to always use JDK 21 for Gradle
-      run: mkdir ~/.gradle && echo "org.gradle.java.home=$JAVA_HOME_21_X64" >> ~/.gradle/gradle.properties
+      run: mkdir -p ~/.gradle && echo "org.gradle.java.home=$JAVA_HOME_21_X64" >> ~/.gradle/gradle.properties
 
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
     # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
           {version: '11', experimental: false},
           {version: '17', experimental: false},
           {version: '25', experimental: false},
+          {version: '26', experimental: false},
           {version: 'EA', experimental: true}]
         exclude:
           # JDK 8 does not allow toolchains, so testing 'cftests-junit-jdk21' is unnecessary.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
           {version: '11', experimental: false},
           {version: '17', experimental: false},
           {version: '25', experimental: false},
-          {version: 'ea', experimental: true}]
+          {version: 'EA', experimental: true}]
         exclude:
           # JDK 8 does not allow toolchains, so testing 'cftests-junit-jdk21' is unnecessary.
           - script: 'cftests-junit-jdk21'
@@ -210,7 +210,7 @@ jobs:
         java-version: ${{ matrix.java.version }}
         distribution: 'zulu'
         cache: 'gradle'
-    - name: Set up JDK $JDK_EA_MAJOR
+    - name: Set up JDK ${{ env.JDK_EA_MAJOR }}
       if: ${{ matrix.java.version == 'EA' }}
       uses: oracle-actions/setup-java@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
       uses: actions/setup-java@v5
       with:
         java-version: ${{ matrix.java_version }}
-        distribution: 'temurin'
+        distribution: 'zulu'
+        cache: 'gradle'
 
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
     # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
@@ -90,7 +91,8 @@ jobs:
       uses: actions/setup-java@v5
       with:
         java-version: ${{ matrix.java_version }}
-        distribution: 'temurin'
+        distribution: 'zulu'
+        cache: 'gradle'
 
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
     # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
@@ -121,8 +123,7 @@ jobs:
     env:
       JAVA_VERSION: ${{ matrix.java.version }}
       USE_BAZEL_VERSION: "9.0.1"
-      JDK_EA_MAJOR: "26"
-      JDK_EA_BUILD: "35"
+      JDK_EA_MAJOR: "27"
     strategy:
       fail-fast: true
       matrix:
@@ -199,13 +200,24 @@ jobs:
       with:
         # Install JDK 21 first, to make it available to Gradle using `gradle.properties` below.
         java-version: 21
-        distribution: 'temurin'
+        distribution: 'zulu'
+        cache: 'gradle'
     - name: Set up JDK ${{ matrix.java.version }}
+      if: ${{ matrix.java.version != 'EA' }}
       uses: actions/setup-java@v5
       with:
         # Install the requested JDK second, to make it the default on which everything else runs.
-        java-version: ${{ matrix.java.version == 'ea' && format('{0}.0.0-ea.{1}.0.ea', env.JDK_EA_MAJOR, env.JDK_EA_BUILD) || matrix.java.version }}
-        distribution: 'temurin'
+        java-version: ${{ matrix.java.version }}
+        distribution: 'zulu'
+        cache: 'gradle'
+    - name: Set up JDK $JDK_EA_MAJOR
+      if: ${{ matrix.java.version == 'EA' }}
+      uses: oracle-actions/setup-java@v1
+      with:
+        # Install the requested EA JDK second, to make it the default on which everything else runs.
+        website: jdk.java.net
+        release: ${{ matrix.java.version }}
+        cache: 'gradle'
     - name: Inject JAVA_HOME_21_64 into `gradle.properties` to always use JDK 21 for Gradle
       run: mkdir ~/.gradle && echo "org.gradle.java.home=$JAVA_HOME_21_X64" >> ~/.gradle/gradle.properties
 
@@ -244,7 +256,7 @@ jobs:
       # Set the JDK version to use, allowing us to e.g. run Java 25 while gradle does not work
       # on Java 25 yet.
       env:
-        ORG_GRADLE_PROJECT_useJdkVersion: ${{ matrix.java.version == 'ea' && env.JDK_EA_MAJOR || matrix.java.version }}
+        ORG_GRADLE_PROJECT_useJdkVersion: ${{ matrix.java.version == 'EA' && env.JDK_EA_MAJOR || matrix.java.version }}
 
   # Sanity tests on Windows and MacOS.
   otheros:
@@ -266,7 +278,8 @@ jobs:
       uses: actions/setup-java@v5
       with:
         java-version: ${{ matrix.java_version }}
-        distribution: 'temurin'
+        distribution: 'zulu'
+        cache: 'gradle'
 
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
     # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       JAVA_VERSION: ${{ matrix.java.version }}
       USE_BAZEL_VERSION: "9.0.1"
       JDK_EA_MAJOR: "27"
-      JDK_EA_BUILD: "15"
+      JDK_EA_BUILD: "14"
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
Temporary Renovate test. This branch sets the pinned JDK 27 EA build below the current latest so Renovate can propose the upgrade.