### PR TITLE
CI: use direct URI for JDK 27 EA builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,10 @@ jobs:
       if: ${{ matrix.java.version == 'EA' }}
       uses: oracle-actions/setup-java@v1
       with:
+        # Install the requested EA JDK second, to make it the default on which everything else runs.
         # Pin EA builds by direct archive URI.
+        # If the URI stops working, check for the updated pattern here:
+        # https://github.com/oracle-actions/setup-java/blob/main/jdk.java.net-uri.properties
         uri: ${{ format('https://download.java.net/java/early_access/jdk{0}/{1}/GPL/openjdk-{0}-ea+{1}_linux-x64_bin.tar.gz', env.JDK_EA_MAJOR, env.JDK_EA_BUILD) }}
         install-as-version: ${{ env.JDK_EA_MAJOR }}
     - name: Inject JAVA_HOME_21_64 into `gradle.properties` to always use JDK 21 for Gradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,10 +216,10 @@ jobs:
       if: ${{ matrix.java.version == 'EA' }}
       uses: oracle-actions/setup-java@v1
       with:
-        # Install the requested EA JDK second, to make it the default on which everything else runs.
-        website: jdk.java.net
-        release: ${{ env.JDK_EA_MAJOR }}
-        version: ${{ format('{0}-ea+{1}', env.JDK_EA_MAJOR, env.JDK_EA_BUILD) }}
+        # Pin the archive URI directly because oracle-actions/setup-java's resolver
+        # drops older EA builds from jdk.java.net-uri.properties.
+        uri: ${{ format('https://download.java.net/java/early_access/jdk{0}/{1}/GPL/openjdk-{0}-ea+{1}_linux-x64_bin.tar.gz', env.JDK_EA_MAJOR, env.JDK_EA_BUILD) }}
+        install-as-version: ${{ env.JDK_EA_MAJOR }}
     - name: Inject JAVA_HOME_21_64 into `gradle.properties` to always use JDK 21 for Gradle
       run: mkdir -p ~/.gradle && echo "org.gradle.java.home=$JAVA_HOME_21_X64" >> ~/.gradle/gradle.properties
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,8 +216,7 @@ jobs:
       if: ${{ matrix.java.version == 'EA' }}
       uses: oracle-actions/setup-java@v1
       with:
-        # Pin the archive URI directly because oracle-actions/setup-java's resolver
-        # drops older EA builds from jdk.java.net-uri.properties.
+        # Pin EA builds by direct archive URI.
         uri: ${{ format('https://download.java.net/java/early_access/jdk{0}/{1}/GPL/openjdk-{0}-ea+{1}_linux-x64_bin.tar.gz', env.JDK_EA_MAJOR, env.JDK_EA_BUILD) }}
         install-as-version: ${{ env.JDK_EA_MAJOR }}
     - name: Inject JAVA_HOME_21_64 into `gradle.properties` to always use JDK 21 for Gradle


### PR DESCRIPTION
Tests replacing oracle-actions/setup-java release/version resolution for the EA lane with a direct archive URI built from JDK_EA_MAJOR and JDK_EA_BUILD. This is intended to keep pinned EA builds usable even after oracle-actions/setup-java drops older entries from jdk.java.net-uri.properties.